### PR TITLE
Supported xml attributes.

### DIFF
--- a/syntaxes/k.tmLanguage
+++ b/syntaxes/k.tmLanguage
@@ -82,7 +82,7 @@
 		</dict>
 		<dict>
 		    <key>match</key> <!--> Colour Light-red <-->
-			<string>\b(strict|avoid|prefer|bracket|non-assoc|seqstrict|left|right|macro|token|notInRules|autoReject|structural|latex)\b</string>
+			<string>\b(strict|avoid|prefer|bracket|non-assoc|seqstrict|left|right|macro|token|notInRules|autoReject|structural|latex|binder)\b</string>
 			<key>name</key>
 			<string>string.regexp.k</string>
 		</dict>

--- a/syntaxes/k.tmLanguage
+++ b/syntaxes/k.tmLanguage
@@ -108,7 +108,7 @@
 		<!-- tag -->
 		<dict>
 			<key>begin</key>
-			<string>(&lt;)\s*([\w\d]+)</string>
+			<string>(&lt;)\s*([\w\d\-\_]+)</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>
@@ -138,7 +138,7 @@
 			<array>
 				<dict>
 					<key>match</key>
-					<string>([\w\d]+)\s*\=\s*(\".+?\")</string>
+					<string>([\w\d\-\_]+)\s*\=\s*(\".+?\")</string>
 					<key>captures</key>
 					<dict>
 						<key>1</key>
@@ -157,7 +157,7 @@
 		</dict>
 		<dict>
 			<key>match</key> 
-			<string>(&lt;)\s*\/([\w\d]+?)\s*(&gt;)</string>
+			<string>(&lt;)\s*\/([\w\d\-\_]+?)\s*(&gt;)</string>
 			<key>captures</key>
 			<dict>
 				<key>1</key>

--- a/syntaxes/k.tmLanguage
+++ b/syntaxes/k.tmLanguage
@@ -82,7 +82,7 @@
 		</dict>
 		<dict>
 		    <key>match</key> <!--> Colour Light-red <-->
-			<string>\b(strict|avoid|prefer|bracket|non-assoc|seqstrict|left|right|macro|token|notInRules|autoReject|structural)\b</string>
+			<string>\b(strict|avoid|prefer|bracket|non-assoc|seqstrict|left|right|macro|token|notInRules|autoReject|structural|latex)\b</string>
 			<key>name</key>
 			<string>string.regexp.k</string>
 		</dict>
@@ -96,7 +96,7 @@
 			<key>match</key> <!--> Colour orange <-->
 			<string>\b(module|endmodule)\b</string>
 			<key>name</key>
-			<string>warn-token</string>
+			<string>keyword.module.k</string>
 		</dict>
 		<dict>
 			<key>match</key> <!--> Colour Light green <-->
@@ -104,12 +104,80 @@
 			<key>name</key>
 			<string>constant.numeric.k</string>
 		</dict>
+		
+		<!-- tag -->
 		<dict>
-			<key>match</key> <!--> tags <-->
-			<string>&lt;\/?[\w\d]*&gt;</string>
-			<key>name</key>
-			<string>constant.regexp.emphasis.strong.tags.k</string>
+			<key>begin</key>
+			<string>(&lt;)\s*([\w\d]+)</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.tag.k</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>entity.name.tag.k</string>
+				</dict>
+			</dict>
+
+			<key>end</key>
+			<string>\s*(&gt;)</string>
+			<key>endCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.tag.k</string>
+				</dict>
+			</dict>
+
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>match</key>
+					<string>([\w\d]+)\s*\=\s*(\".+?\")</string>
+					<key>captures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>constant.regexp.emphasis.strong.tags.k</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>string.quoted.double.k</string>
+						</dict>
+					</dict>
+				</dict>
+			</array>
 		</dict>
+		<dict>
+			<key>match</key> 
+			<string>(&lt;)\s*\/([\w\d]+?)\s*(&gt;)</string>
+			<key>captures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.tag.k</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>entity.name.tag.k</string>
+				</dict>
+				<key>3</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.tag.k</string>
+				</dict>
+			</dict>
+		</dict>
+
 		<dict>
 			<key>match</key>
 			<string>\+|-|/|\*|%|=|\^|~|\||\?|&lt;|&gt;|&amp;</string>


### PR DESCRIPTION
1. Supported highlighting for configuration XML attributes (see issue [#3](https://github.com/LucianCumpata/K-VSCode/issues/3)).  
2. Fixed `module` and `endmodule` keywords highlighting. 
3. Added highlighting for `latex`, `binder` attributes.   

**Screenshot**

Before:

![screen shot 2017-09-26 at 2 50 58 pm](https://user-images.githubusercontent.com/1908863/30881063-2304f5fa-a2ca-11e7-8257-40b6055c7e07.png)

Now:  

![screen shot 2017-09-26 at 2 50 54 pm](https://user-images.githubusercontent.com/1908863/30881071-27cb54f8-a2ca-11e7-8068-95e96197379d.png)


Please have a look when you have time! Thanks for your work.  
  